### PR TITLE
Ensure `hipconfig -C` output does not contain `\n`

### DIFF
--- a/docs/how-to/gpu-enabled-mpi.rst
+++ b/docs/how-to/gpu-enabled-mpi.rst
@@ -100,7 +100,7 @@ ROCm-supported AMD GPUs. The ``--enable-rocm`` option exposes this functionality
         --with-rocm=/opt/rocm \
         CC=$OMPI_DIR/bin/mpicc CXX=$OMPI_DIR/bin/mpicxx \
         LDFLAGS="-L$OMPI_DIR/lib/ -lmpi -L/opt/rocm/lib/ \
-        $(hipconfig -C) -lamdhip64" CXXFLAGS="-std=c++11"
+        $(hipconfig -C | tr -d '\n') -lamdhip64" CXXFLAGS="-std=c++11"
     make -j $(nproc)
 
 Intra-node run


### PR DESCRIPTION
Some system will trigger `Makefile:241 missing separator` error and prevent make to execute correctly