### PR TITLE
Update "Ensure `hipconfig -C` output does not contain `\n`"

### DIFF
--- a/docs/how-to/gpu-enabled-mpi.rst
+++ b/docs/how-to/gpu-enabled-mpi.rst
@@ -98,7 +98,7 @@ You can use OSU Micro Benchmarks (OMB) to evaluate the performance of various pr
     ./configure --enable-rocm \
         --with-rocm=/opt/rocm \
         CC=$OMPI_DIR/bin/mpicc CXX=$OMPI_DIR/bin/mpicxx \
-        LDFLAGS="-L$OMPI_DIR/lib/ -lmpi -L/opt/rocm/lib/ \
+        LDFLAGS="-L$OMPI_DIR/lib/ -lmpi -L/opt/rocm/lib/ -lamdhip64 \ CFLAGS="$(hipconfig -C | tr -d '\n') " CXXFLAGS="-std=c++11" \
         $(hipconfig -C) -lamdhip64" CXXFLAGS="-std=c++11"
     make -j $(nproc)
 

--- a/docs/how-to/gpu-enabled-mpi.rst
+++ b/docs/how-to/gpu-enabled-mpi.rst
@@ -98,8 +98,9 @@ You can use OSU Micro Benchmarks (OMB) to evaluate the performance of various pr
     ./configure --enable-rocm \
         --with-rocm=/opt/rocm \
         CC=$OMPI_DIR/bin/mpicc CXX=$OMPI_DIR/bin/mpicxx \
-        LDFLAGS="-L$OMPI_DIR/lib/ -lmpi -L/opt/rocm/lib/ -lamdhip64 \ CFLAGS="$(hipconfig -C | tr -d '\n') " CXXFLAGS="-std=c++11" \
-        $(hipconfig -C) -lamdhip64" CXXFLAGS="-std=c++11"
+        LDFLAGS="-L$OMPI_DIR/lib/ -lmpi -L/opt/rocm/lib/ -lamdhip64" \
+        CFLAGS="$(hipconfig -C | tr -d '\n')"
+        CXXFLAGS="-std=c++11"
     make -j $(nproc)
 
 Intra-node run

--- a/docs/how-to/gpu-enabled-mpi.rst
+++ b/docs/how-to/gpu-enabled-mpi.rst
@@ -99,7 +99,7 @@ You can use OSU Micro Benchmarks (OMB) to evaluate the performance of various pr
         --with-rocm=/opt/rocm \
         CC=$OMPI_DIR/bin/mpicc CXX=$OMPI_DIR/bin/mpicxx \
         LDFLAGS="-L$OMPI_DIR/lib/ -lmpi -L/opt/rocm/lib/ \
-        $(hipconfig -C | tr -d '\n') -lamdhip64" CXXFLAGS="-std=c++11"
+        $(hipconfig -C) -lamdhip64" CXXFLAGS="-std=c++11"
     make -j $(nproc)
 
 Intra-node run


### PR DESCRIPTION
Reverts ROCm/gpu-cluster-networking#37

@GindaChen opening revert to float some additional suggestions by @paklui, in case you'd like to test them.