### PR TITLE
05-15-25 Hotfix

### DIFF
--- a/docs/how-to/single-node-config.rst
+++ b/docs/how-to/single-node-config.rst
@@ -253,7 +253,7 @@ deploying (InfiniBand or RoCE).
 
      sudo mlxconfig -d /dev/mst/mt4123_pciconf0 s ADVANCED_PCI_SETTINGS=1
 
-     sudo mlxconfig -d /dev/mst/mt4123_pciconf0 s MAX_ACC_OUT_READ=44
+     sudo mlxconfig -d /dev/mst/mt4123_pciconf0 s MAX_ACC_OUT_READ=128
 
      sudo mlxconfig -d /dev/mst/mt4123_pciconf0 s PCI_WR_ORDERING=1
 


### PR DESCRIPTION
Updating the MAX_ACC_OUT_READ value recommended for Mellanox NICs in the Single Node Networking Guide. Performance is found to generally improve when the value is set to 128 instead of 44.