### PR TITLE
07-16-25 Hotfix

### DIFF
--- a/docs/how-to/single-node-config.rst
+++ b/docs/how-to/single-node-config.rst
@@ -52,7 +52,7 @@ Before following the steps in the following sections, ensure you have completed 
 
 #. Configure IOMMU settings.
 
-   a. Add ``iommu=pt`` and ``pci=bfsort`` to the ``GRUB_CMDLINE_LINUX_DEFAULT`` entry in ``/etc/default/grub``.
+   a. Add ``iommu=pt``, ``pci=realloc=off``, and ``pci=bfsort`` to the ``GRUB_CMDLINE_LINUX_DEFAULT`` entry in ``/etc/default/grub``.
 
    b. Run ``sudo update-grub``, then reboot.
 


### PR DESCRIPTION
Updating the grub settings: `pci=realloc=off` is found to be a generally helpful setting and should be included in standard instructions.